### PR TITLE
Fix markdown rendering by utilizing remark-breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "react-ol-wrapper": "^0.2.9",
         "react-select": "^5.10.2",
         "readline-sync": "^1.4.10",
+        "remark-breaks": "^4.0.0",
         "simplebar-react": "^3.3.2",
         "source-map-explorer": "^2.5.3"
       },
@@ -7096,6 +7097,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.1.tgz",
@@ -7171,6 +7200,20 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9265,6 +9308,21 @@
       "dependencies": {
         "bindings": "^1.3.0",
         "node-addon-api": "^1.3.0"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-ol-wrapper": "^0.2.9",
     "react-select": "^5.10.2",
     "readline-sync": "^1.4.10",
+    "remark-breaks": "^4.0.0",
     "simplebar-react": "^3.3.2",
     "source-map-explorer": "^2.5.3"
   },

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -2,33 +2,23 @@ import { useContext } from "react";
 import { AppContext } from "../context";
 
 import ReactMarkdown from "react-markdown";
-import DOMPurify from "dompurify";
+import remarkBreaks from "remark-breaks";
 
 const MarkdownRenderer = ({ children }) => {
   const { userSettings } = useContext(AppContext);
 
-  const preprocessContent = content => {
-    if (content === undefined || content === null) return "";
-    return content.replace(/\n/g, "\n\n");
-  };
+  const content = children == null ? "" : String(children);
 
   const components = {
-    p: props => {
-      return (
-        <span>
-          {props.children}
-          <br />
-        </span>
-      );
-    },
-    img: props => <>{!userSettings.data_saver && <img {...props} style={{ width: "100%" }} alt=" " />}</>,
-    a: ({ node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />, // Added this line
+    img: ({ node, ...props }) => <>{!userSettings.data_saver && <img {...props} style={{ width: "100%" }} alt=" " />}</>,
+    a: ({ node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,
   };
 
-  const preprocessedContent = preprocessContent(children);
-  const sanitizedContent = DOMPurify.sanitize(preprocessedContent);
-
-  return <ReactMarkdown components={components} children={sanitizedContent} />;
+  return (
+    <ReactMarkdown remarkPlugins={[remarkBreaks]} components={components}>
+      {content}
+    </ReactMarkdown>
+  );
 };
 
 export default MarkdownRenderer;


### PR DESCRIPTION
Integrate `remark-breaks` to handle newlines in markdown content, eliminating the need for manual newline processing and sanitization. This change leverages the existing sanitization in `react-markdown`.